### PR TITLE
Better whitespace handling and preference of initial order

### DIFF
--- a/initialcon/__init__.py
+++ b/initialcon/__init__.py
@@ -40,7 +40,20 @@ urlpatterns = patterns('initialcon',
 
 # Returns the initials of the name
 def get_initials(name, sep=''):
-    return sep.join([word[0] for word in name.split(' ')[:2]])
+    if name:
+
+        # grabs the first letter of each token in the name
+        initials = [word[0] for word in name.split()]
+
+        if len(initials) == 1:
+
+            # only one initial
+            return initials[0]
+
+        # join the first and last of multiple initials
+        return sep.join([initials[0], initials[-1]])
+
+    return ''
 
 def generate(request, name):
     """


### PR DESCRIPTION
This pull request fixes cases where there were multiple spaces in the name, or if the name was only whitespace itself. It also prefers the first and last initial rather than the first two initials. It still returns only the first initial if only one initial was found.
